### PR TITLE
ジャムへ申込可能にする ／ 修正（開催中止ボタン、認証）

### DIFF
--- a/components/CancelEntryButton.tsx
+++ b/components/CancelEntryButton.tsx
@@ -21,18 +21,15 @@ const CancelEntryButton: NextPage<CancelEntryButtonProps> = ({
   const [cancelEntry, mutationResult] =
     useMutation<CancelEntryData>(CANCEL_ENTRY)
   const error = mutationResult.error
-
-  if (session.userId == jam.userId) return null
-  if (!jam.candidates?.some((c) => parseInt(c.id) === session.userId))
-    return null
-
   const handleEntry = async () => {
     await cancelEntry({ variables: { jamId: parseInt(jam.id) } })
-
     error
       ? alert(`Error: ${JSON.stringify(error)}`)
       : setMessage('Successfully Cancel Entry')
   }
+
+  if (!jam.candidates?.some((c) => parseInt(c.id) === session.userId))
+    return null
 
   return (
     <>

--- a/components/CancelEntryButton.tsx
+++ b/components/CancelEntryButton.tsx
@@ -1,0 +1,45 @@
+import { useMutation } from '@apollo/client'
+import { NextPage } from 'next'
+import { Session } from 'next-auth'
+import { useState } from 'react'
+import { Jam } from '../types'
+import {
+  CANCEL_ENTRY,
+  CancelEntryData,
+} from '../graphql/mutations/cancel-entry.mutation'
+
+interface CancelEntryButtonProps {
+  jam: Jam
+  session: Session // WithSessionから受け取る
+}
+
+const CancelEntryButton: NextPage<CancelEntryButtonProps> = ({
+  jam,
+  session,
+}) => {
+  const [message, setMessage] = useState<string>('')
+  const [cancelEntry, mutationResult] =
+    useMutation<CancelEntryData>(CANCEL_ENTRY)
+  const error = mutationResult.error
+
+  if (session.userId == jam.userId) return null
+  if (!jam.candidates?.some((c) => parseInt(c.id) === session.userId))
+    return null
+
+  const handleEntry = async () => {
+    await cancelEntry({ variables: { jamId: parseInt(jam.id) } })
+
+    error
+      ? alert(`Error: ${JSON.stringify(error)}`)
+      : setMessage('Successfully Cancel Entry')
+  }
+
+  return (
+    <>
+      <button onClick={handleEntry}>申込キャンセル</button>
+      {message ? <span className="message">{message}</span> : null}
+    </>
+  )
+}
+
+export default CancelEntryButton

--- a/components/CancelJamButton.tsx
+++ b/components/CancelJamButton.tsx
@@ -1,0 +1,36 @@
+import { useMutation } from '@apollo/client'
+import { NextPage } from 'next'
+import { useState } from 'react'
+import {
+  CANCEL_JAM,
+  CancelJamData,
+} from '../graphql/mutations/cancel-jam.mutation'
+import { Jam } from 'types'
+import { Session } from 'next-auth'
+
+interface CancelJamButtonProps {
+  jam: Jam
+  session: Session
+}
+
+const CancelJamButton: NextPage<CancelJamButtonProps> = ({ jam }) => {
+  const [message, setMessage] = useState<string>('')
+  const [cancelJam, cancelResult] = useMutation<CancelJamData>(CANCEL_JAM)
+  const cancelError = cancelResult.error
+  const handleCancel = async () => {
+    await cancelJam({ variables: { id: parseInt(jam.id) } })
+    cancelError
+      ? alert(`Error: ${JSON.stringify(cancelError)}`)
+      : setMessage('Successfully canceled')
+  }
+  if (jam.canceledAt) return null
+
+  return (
+    <>
+      <button onClick={handleCancel}>中止</button>
+      {message ? <span className="message">{message}</span> : null}
+    </>
+  )
+}
+
+export default CancelJamButton

--- a/components/CandidatesList.tsx
+++ b/components/CandidatesList.tsx
@@ -1,0 +1,28 @@
+import Link from 'next/link'
+import { NextPage } from 'next'
+import { User } from '../types'
+
+interface CandidatesListProps {
+  candidates: [User]
+}
+
+const CandidatesList: NextPage<CandidatesListProps> = ({ candidates }) => {
+  if (!candidates) return null
+
+  return (
+    <ul>
+      {candidates.map((candidate, index) => {
+        return (
+          <li key={index}>
+            {candidate.nickname}{' '}
+            <Link href={`/users/${candidate.id}`}>
+              <a>[Detail]</a>
+            </Link>
+          </li>
+        )
+      })}
+    </ul>
+  )
+}
+
+export default CandidatesList

--- a/components/EditJamItem.tsx
+++ b/components/EditJamItem.tsx
@@ -60,7 +60,7 @@ const EditJamItem: NextPage<EditJamItemProps> = ({ id }) => {
   }
 
   return (
-    <WithSession userId={parseInt(jam.userId)}>
+    <WithSession userId={parseInt(jam.userId)} isOwner={true}>
       <JamForm
         jam={jam}
         message={message}

--- a/components/EntryButton.tsx
+++ b/components/EntryButton.tsx
@@ -1,6 +1,6 @@
 import { useMutation } from '@apollo/client'
 import { NextPage } from 'next'
-import { useSession } from 'next-auth/react'
+import { Session } from 'next-auth'
 import { useState } from 'react'
 import { Jam } from 'types'
 import {
@@ -10,17 +10,17 @@ import {
 
 interface EntryButtonProps {
   jam: Jam
+  session: Session // WithSessionから受け取る
 }
 
-const EntryButton: NextPage<EntryButtonProps> = ({ jam }) => {
+const EntryButton: NextPage<EntryButtonProps> = ({ jam, session }) => {
   const [message, setMessage] = useState<string>('')
   const [entryJam, entryResult] = useMutation<EntryJamData>(ENTRY_JAM)
   const entryError = entryResult.error
 
-  const { data: session, status } = useSession()
-  const loading = status === 'loading'
-  if (loading || !session) return null
   if (session.userId == jam.userId) return null
+  if (jam.candidates?.some((c) => parseInt(c.id) === session.userId))
+    return null
 
   const handleEntry = async () => {
     await entryJam({ variables: { jamId: parseInt(jam.id) } })

--- a/components/EntryButton.tsx
+++ b/components/EntryButton.tsx
@@ -17,17 +17,15 @@ const EntryButton: NextPage<EntryButtonProps> = ({ jam, session }) => {
   const [message, setMessage] = useState<string>('')
   const [entryJam, entryResult] = useMutation<EntryJamData>(ENTRY_JAM)
   const entryError = entryResult.error
-
-  if (session.userId == jam.userId) return null
-  if (jam.candidates?.some((c) => parseInt(c.id) === session.userId))
-    return null
-
   const handleEntry = async () => {
     await entryJam({ variables: { jamId: parseInt(jam.id) } })
     entryError
       ? alert(`Error: ${JSON.stringify(entryError)}`)
       : setMessage('Successfully Entry Jam')
   }
+
+  if (jam.candidates?.some((c) => parseInt(c.id) === session.userId))
+    return null
 
   return (
     <>

--- a/components/EntryButton.tsx
+++ b/components/EntryButton.tsx
@@ -1,0 +1,40 @@
+import { useMutation } from '@apollo/client'
+import { NextPage } from 'next'
+import { useSession } from 'next-auth/react'
+import { useState } from 'react'
+import { Jam } from 'types'
+import {
+  ENTRY_JAM,
+  EntryJamData,
+} from '../graphql/mutations/entry-jam.mutation'
+
+interface EntryButtonProps {
+  jam: Jam
+}
+
+const EntryButton: NextPage<EntryButtonProps> = ({ jam }) => {
+  const [message, setMessage] = useState<string>('')
+  const [entryJam, entryResult] = useMutation<EntryJamData>(ENTRY_JAM)
+  const entryError = entryResult.error
+
+  const { data: session, status } = useSession()
+  const loading = status === 'loading'
+  if (loading || !session) return null
+  if (session.userId == jam.userId) return null
+
+  const handleEntry = async () => {
+    await entryJam({ variables: { jamId: parseInt(jam.id) } })
+    entryError
+      ? alert(`Error: ${JSON.stringify(entryError)}`)
+      : setMessage('Successfully Entry Jam')
+  }
+
+  return (
+    <>
+      <button onClick={handleEntry}>申込</button>
+      {message ? <span className="message">{message}</span> : null}
+    </>
+  )
+}
+
+export default EntryButton

--- a/components/JamItem.tsx
+++ b/components/JamItem.tsx
@@ -12,6 +12,7 @@ import {
 } from '../graphql/mutations/uncancel-jam.mutation'
 import WithSession from '@/WithSession'
 import EntryButton from '@/EntryButton'
+import CancelEntryButton from '@/CancelEntryButton'
 import Link from 'next/link'
 import CandidatesList from '@/CandidatesList'
 
@@ -65,6 +66,7 @@ const JamItem: NextPage<JamItemProps> = ({ id }) => {
       </WithSession>
       <WithSession>
         <EntryButton jam={jam} />
+        <CancelEntryButton jam={jam} />
       </WithSession>
       <ul>
         <li>{jam.id}</li>

--- a/components/JamItem.tsx
+++ b/components/JamItem.tsx
@@ -24,14 +24,14 @@ const JamItem: NextPage<JamItemProps> = ({ id }) => {
 
   return (
     <>
-      <WithSession userId={jam.userId}>
+      <WithSession userId={jam.userId} isOwner={true}>
         <Link href={`/jams/${id}/edit`}>
           <button>Edit</button>
         </Link>
         <CancelJamButton jam={jam} />
         <UncancelJamButton jam={jam} />
       </WithSession>
-      <WithSession>
+      <WithSession userId={jam.userId} isOwner={false}>
         <EntryButton jam={jam} />
         <CancelEntryButton jam={jam} />
       </WithSession>

--- a/components/JamItem.tsx
+++ b/components/JamItem.tsx
@@ -11,6 +11,7 @@ import {
   UncancelJamData,
 } from '../graphql/mutations/uncancel-jam.mutation'
 import WithSession from '@/WithSession'
+import EntryButton from '@/EntryButton'
 import Link from 'next/link'
 
 interface JamItemProps {
@@ -60,6 +61,9 @@ const JamItem: NextPage<JamItemProps> = ({ id }) => {
         </Link>
         <button onClick={cancelButtonHundler}>{cancelButtonLabel}</button>
         {message ? <span className="message">{message}</span> : null}
+      </WithSession>
+      <WithSession>
+        <EntryButton jam={jam} />
       </WithSession>
       <ul>
         <li>{jam.id}</li>

--- a/components/JamItem.tsx
+++ b/components/JamItem.tsx
@@ -13,6 +13,7 @@ import {
 import WithSession from '@/WithSession'
 import EntryButton from '@/EntryButton'
 import Link from 'next/link'
+import CandidatesList from '@/CandidatesList'
 
 interface JamItemProps {
   id: string
@@ -75,6 +76,8 @@ const JamItem: NextPage<JamItemProps> = ({ id }) => {
         <li>{jam.createdAt}</li>
         <li>{jam.updatedAt}</li>
       </ul>
+      <h2>参加希望者</h2>
+      <CandidatesList candidates={jam.candidates} />
     </>
   )
 }

--- a/components/JamItem.tsx
+++ b/components/JamItem.tsx
@@ -1,16 +1,9 @@
-import { useQuery, useMutation } from '@apollo/client'
+import { useQuery } from '@apollo/client'
 import { NextPage } from 'next'
 import { JAM_QUERY, JamData } from '../graphql/queries/jam.query'
-import { useState } from 'react'
-import {
-  CANCEL_JAM,
-  CancelJamData,
-} from '../graphql/mutations/cancel-jam.mutation'
-import {
-  UNCANCEL_JAM,
-  UncancelJamData,
-} from '../graphql/mutations/uncancel-jam.mutation'
 import WithSession from '@/WithSession'
+import CancelJamButton from '@/CancelJamButton'
+import UncancelJamButton from '@/UncancelJamButton'
 import EntryButton from '@/EntryButton'
 import CancelEntryButton from '@/CancelEntryButton'
 import Link from 'next/link'
@@ -21,39 +14,13 @@ interface JamItemProps {
 }
 
 const JamItem: NextPage<JamItemProps> = ({ id }) => {
-  const [message, setMessage] = useState<string>('')
   const { loading, error, data } = useQuery<JamData>(JAM_QUERY, {
     variables: { id: parseInt(id) },
   })
-  const [cancelJam, cancelResult] = useMutation<CancelJamData>(CANCEL_JAM)
-  const [uncancelJam, uncancelResult] =
-    useMutation<UncancelJamData>(UNCANCEL_JAM)
-  const cancelError = cancelResult.error
-  const uncancelError = uncancelResult.error
-
   if (loading) return <p>Loading...</p>
   if (error) return <p>Error: {JSON.stringify(error)}</p>
-
   const { jam } = data
   if (!jam) return null
-
-  const mutationVariables = { id: parseInt(jam.id) }
-  const handleCancel = async () => {
-    await cancelJam({ variables: mutationVariables })
-    cancelError
-      ? alert(`Error: ${JSON.stringify(cancelError)}`)
-      : setMessage('Successfully canceled')
-  }
-
-  const handleUncancel = async () => {
-    await uncancelJam({ variables: mutationVariables })
-    uncancelError
-      ? alert(`Error: ${JSON.stringify(uncancelError)}`)
-      : setMessage('Successfully uncanceled')
-  }
-
-  const cancelButtonHundler = jam.canceledAt ? handleUncancel : handleCancel
-  const cancelButtonLabel = jam.canceledAt ? 'uncancel' : 'cancel'
 
   return (
     <>
@@ -61,8 +28,8 @@ const JamItem: NextPage<JamItemProps> = ({ id }) => {
         <Link href={`/jams/${id}/edit`}>
           <button>Edit</button>
         </Link>
-        <button onClick={cancelButtonHundler}>{cancelButtonLabel}</button>
-        {message ? <span className="message">{message}</span> : null}
+        <CancelJamButton jam={jam} />
+        <UncancelJamButton jam={jam} />
       </WithSession>
       <WithSession>
         <EntryButton jam={jam} />

--- a/components/UncancelJamButton.tsx
+++ b/components/UncancelJamButton.tsx
@@ -1,0 +1,37 @@
+import { useMutation } from '@apollo/client'
+import { NextPage } from 'next'
+import { useState } from 'react'
+import {
+  UNCANCEL_JAM,
+  UncancelJamData,
+} from '../graphql/mutations/uncancel-jam.mutation'
+import { Jam } from 'types'
+import { Session } from 'next-auth'
+
+interface UncancelJamButtonProps {
+  jam: Jam
+  session: Session
+}
+
+const UncancelJamButton: NextPage<UncancelJamButtonProps> = ({ jam }) => {
+  const [message, setMessage] = useState<string>('')
+  const [uncancelJam, uncancelResult] =
+    useMutation<UncancelJamData>(UNCANCEL_JAM)
+  const uncancelError = uncancelResult.error
+  const handleUncancel = async () => {
+    await uncancelJam({ variables: { id: parseInt(jam.id) } })
+    uncancelError
+      ? alert(`Error: ${JSON.stringify(uncancelError)}`)
+      : setMessage('Successfully uncanceled')
+  }
+  if (!jam.canceledAt) return null
+
+  return (
+    <>
+      <button onClick={handleUncancel}>中止取消</button>
+      {message ? <span className="message">{message}</span> : null}
+    </>
+  )
+}
+
+export default UncancelJamButton

--- a/components/WithSession.tsx
+++ b/components/WithSession.tsx
@@ -1,9 +1,9 @@
-import { ReactElement } from 'react'
+import { ReactElement, cloneElement, Children } from 'react'
 import { NextPage } from 'next'
 import { useSession } from 'next-auth/react'
 
 type WithSessionProps = {
-  children: ReactElement
+  children: [ReactElement]
   userId?: number
 }
 
@@ -11,16 +11,13 @@ const WithSession: NextPage<WithSessionProps> = ({ children, userId }) => {
   const { data: session, status } = useSession()
   const loading = status === 'loading'
   if (loading) return null
+  if (!session) return null
+  if (userId && userId != session.userId) return null
 
-  if (!session) {
-    return null
-  }
-
-  if (userId && userId != session.userId) {
-    return null
-  }
-
-  return children
+  return Children.map(children, (child) => {
+    if (!child) return null
+    return cloneElement(child, { session: session })
+  })
 }
 
 export default WithSession

--- a/components/WithSession.tsx
+++ b/components/WithSession.tsx
@@ -5,14 +5,20 @@ import { useSession } from 'next-auth/react'
 type WithSessionProps = {
   children: [ReactElement]
   userId?: number
+  isOwner?: boolean
 }
 
-const WithSession: NextPage<WithSessionProps> = ({ children, userId }) => {
+const WithSession: NextPage<WithSessionProps> = ({
+  children,
+  userId,
+  isOwner,
+}) => {
   const { data: session, status } = useSession()
   const loading = status === 'loading'
   if (loading) return null
   if (!session) return null
-  if (userId && userId != session.userId) return null
+  if (userId && isOwner && userId != session.userId) return null // 自分が作成したデータのみ許可
+  if (userId && !isOwner && userId == session.userId) return null // 自分が作成していないデータのみ許可
 
   return Children.map(children, (child) => {
     if (!child) return null

--- a/graphql/mutations/cancel-entry.mutation.ts
+++ b/graphql/mutations/cancel-entry.mutation.ts
@@ -1,0 +1,36 @@
+import { gql } from '@apollo/client'
+import { Jam } from '../../types'
+
+export const CANCEL_ENTRY = gql`
+  mutation ($jamId: ID!) {
+    cancelEntry(input: { jamId: $jamId }) {
+      jam {
+        id
+        userId
+        scheduledFor
+        prefectureId
+        place
+        description
+        canceledAt
+        createdAt
+        updatedAt
+        candidates {
+          id
+          name
+          nickname
+          image
+          description
+          location
+          createdAt
+          updatedAt
+        }
+      }
+    }
+  }
+`
+
+export interface CancelEntryData {
+  cancelEntry: {
+    jam: Jam
+  }
+}

--- a/graphql/mutations/entry-jam.mutation.ts
+++ b/graphql/mutations/entry-jam.mutation.ts
@@ -1,5 +1,5 @@
 import { gql } from '@apollo/client'
-import { Entry } from '../../types'
+import { Jam } from '../../types'
 
 export const ENTRY_JAM = gql`
   mutation ($jamId: ID!) {
@@ -31,6 +31,6 @@ export const ENTRY_JAM = gql`
 
 export interface EntryJamData {
   entryJam: {
-    entry: Entry
+    jam: Jam
   }
 }

--- a/graphql/mutations/entry-jam.mutation.ts
+++ b/graphql/mutations/entry-jam.mutation.ts
@@ -1,0 +1,36 @@
+import { gql } from '@apollo/client'
+import { Entry } from '../../types'
+
+export const ENTRY_JAM = gql`
+  mutation ($jamId: ID!) {
+    entryJam(input: { jamId: $jamId }) {
+      jam {
+        id
+        userId
+        scheduledFor
+        prefectureId
+        place
+        description
+        canceledAt
+        createdAt
+        updatedAt
+        candidates {
+          id
+          name
+          nickname
+          image
+          description
+          location
+          createdAt
+          updatedAt
+        }
+      }
+    }
+  }
+`
+
+export interface EntryJamData {
+  entryJam: {
+    entry: Entry
+  }
+}

--- a/graphql/queries/jam.query.ts
+++ b/graphql/queries/jam.query.ts
@@ -13,6 +13,16 @@ export const JAM_QUERY = gql`
       canceledAt
       createdAt
       updatedAt
+      candidates {
+        id
+        name
+        nickname
+        image
+        description
+        location
+        createdAt
+        updatedAt
+      }
     }
   }
 `

--- a/types.ts
+++ b/types.ts
@@ -8,6 +8,7 @@ export interface Jam {
   canceledAt: string
   createdAt: string
   updatedAt: string
+  candidates?: [User]
 }
 
 export interface JamInputType {
@@ -35,4 +36,12 @@ export interface UserInputType {
   nickname: string
   description: string
   location: string
+}
+
+export interface Entry {
+  id: string
+  jamId: string
+  userId: string
+  createdAt: string
+  updatedAt: string
 }

--- a/types.ts
+++ b/types.ts
@@ -37,11 +37,3 @@ export interface UserInputType {
   description: string
   location: string
 }
-
-export interface Entry {
-  id: string
-  jamId: string
-  userId: string
-  createdAt: string
-  updatedAt: string
-}


### PR DESCRIPTION
## TODO
- ジャムへ申込可能にする
- ジャムの申込キャンセル可能にする
- 機能修正
  - WithSession（認証必須のコンポーネント）
    - 所有者フラグ追加を追加して、ジャム作成者 or ジャム作成者以外で表示・非表示しやすいようにした
    用途：申込は作成者以外、開催中止は主催者である作成者のみ、など
    - sessionを子コンポーネントに渡せるようにした
    用途：ログインユーザーが申込済みかどうか判定する、など
- リファクタリング
  - ジャムの開催中止ボタンを申込ボタンと同様にコンポーネント化した