### PR TITLE
ホスト経由の接続方法変更：host.docker.internal を使う

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -11,10 +11,3 @@ services:
       - .:/jamty-frontend
     ports:
       - '4000:3000'
-    networks:
-      - default
-      - jamty-share-network
-
-networks:
-  jamty-share-network:
-    external: true


### PR DESCRIPTION
ホストを経由して別のコンテナにアクセスする方法に
`host.docker.internal`を使用できるため`networks`の設定を削除
https://qiita.com/ijufumi/items/badde64d530e6bade382
https://uepon.hatenadiary.com/entry/2021/06/02/002613